### PR TITLE
fix: Safeguard that owner object has a .once() method

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -66,6 +66,10 @@ const ReqSpy = class ReqSpy extends EventEmitter {
                 return;
             }
 
+            if (typeof resource.owner.once !== 'function') {
+                return;
+            }
+
             resource.owner.once('lookup', (error, address, family, hostname) => {
                 this.emit('host', {
                     hostname,


### PR DESCRIPTION
It seems like there are scenarios where `resource.owner` is undefined and then no `.once()` method, which will cause the module to throw. This checks if there is such a method.