### PR TITLE
fix: remove listeners from open sockets when the spy is disabled

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "extends": ["airbnb-base", "prettier"],
   "plugins": ["prettier"],
+  "env": {
+    "es2021": true
+  },
   "rules": {
     "strict": [0, "global"],
     "class-methods-use-this": [0],

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ which does the interception.
 ### .disable()
 
 Disables the spy from intercept http(s) calls. Under the hood this disables the async
-hook which does the interception.
+hook which does the interception and removes the listeners the spy has attached to
+sockets which are still open, so a disabled spy leaves nothing behind.
 
 ### .metrics
 

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -6,6 +6,8 @@ const Metrics = require('@metrics/client');
 const is = require('@metrics/metric/lib/is');
 
 const hook = Symbol('_hook');
+const lookup = Symbol('_lookup');
+const destroy = Symbol('_destroy');
 
 const ReqSpy = class ReqSpy extends EventEmitter {
     constructor({
@@ -27,14 +29,33 @@ const ReqSpy = class ReqSpy extends EventEmitter {
             value: new Metrics(),
         });
 
+        // Sockets are held weakly so that the spy never keeps one alive, and
+        // are keyed by async id so that the "destroy" hook can drop them again
+        // as they close.
+        Object.defineProperty(this, '_sockets', {
+            value: new Map(),
+        });
+
+        // One shared listener for all sockets: "removeListener" needs a
+        // reference to match on and every socket is handled the same way.
+        Object.defineProperty(this, '_lookup', {
+            value: this[lookup].bind(this),
+        });
+
         Object.defineProperty(this, '_hook', {
             value: asyncHooks.createHook({
                 init: this[hook].bind(this),
+                destroy: this[destroy].bind(this),
             }),
         });
 
+        Object.defineProperty(this, '_enabled', {
+            value: false,
+            writable: true,
+        });
+
         if (enable) {
-            this._hook.enable();
+            this.enable();
         }
 
         const counter = this.metrics.counter({
@@ -62,6 +83,12 @@ const ReqSpy = class ReqSpy extends EventEmitter {
         }
 
         process.nextTick(() => {
+            // The socket is attached to on the next tick, by which time the spy
+            // may have been disabled.
+            if (!this._enabled) {
+                return;
+            }
+
             if (!resource.owner) {
                 return;
             }
@@ -70,23 +97,42 @@ const ReqSpy = class ReqSpy extends EventEmitter {
                 return;
             }
 
-            resource.owner.once('lookup', (error, address, family, hostname) => {
-                this.emit('host', {
-                    hostname,
-                    address: address || null,
-                    family: family || null,
-                    error: (!!error),
-                });
-            });
+            resource.owner.once('lookup', this._lookup);
+
+            this._sockets.set(asyncId, new WeakRef(resource.owner));
         });
     }
 
+    [lookup](error, address, family, hostname) {
+        this.emit('host', {
+            hostname,
+            address: address || null,
+            family: family || null,
+            error: (!!error),
+        });
+    }
+
+    [destroy](asyncId) {
+        this._sockets.delete(asyncId);
+    }
+
     enable() {
+        this._enabled = true;
         this._hook.enable();
     }
 
     disable() {
+        this._enabled = false;
         this._hook.disable();
+
+        this._sockets.forEach(ref => {
+            const socket = ref.deref();
+            if (socket) {
+                socket.removeListener('lookup', this._lookup);
+            }
+        });
+
+        this._sockets.clear();
     }
 };
 

--- a/test/spy.js
+++ b/test/spy.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const { createServer, connect } = require('net');
 const { Writable } = require('stream');
+const { once } = require('events');
 const { test } = require('tap');
 const https = require('https');
 const Spy = require("..");
@@ -127,6 +129,32 @@ test('The spy is enabled, then disabled', async (t) => {
     await get('https://google.com');
 
     t.equal(result.length, 2, 'should have logged two hosts');
+    t.end();
+});
+
+test('The spy detaches from open sockets when disabled', async (t) => {
+    const spy = new Spy({ hostname: 'turing' });
+
+    const server = createServer().listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    // Connecting to an IP address performs no DNS lookup, so the listener the
+    // spy attaches is never consumed and is still there to be counted.
+    const socket = connect(server.address().port, '127.0.0.1');
+    await once(socket, 'connect');
+
+    // Spies from earlier tests are still enabled, so this counts the delta
+    // rather than expecting this spy to be the only listener.
+    const attached = socket.listenerCount('lookup');
+    t.ok(attached > 0, 'should have attached a listener to the socket');
+
+    spy.disable();
+
+    t.equal(socket.listenerCount('lookup'), attached - 1, 'should have removed its listener from the socket');
+
+    socket.destroy();
+    server.close();
+    await once(server, 'close');
     t.end();
 });
 


### PR DESCRIPTION
## What

`disable()` now removes the `lookup` listener from the sockets it attached to, rather than only turning off the async hook.

## Why

The spy attaches a `lookup` listener to every socket the process opens. `disable()` stopped new sockets from being hooked but left the existing ones alone, so a spy that is disabled — or simply abandoned — keeps a listener on every socket that was open at the time. A process that builds and tears down more than ten spies leaves enough behind that each new socket trips Node's default listener cap:

```text
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 lookup listeners added to [Socket].
```

`@borealis/layout-express` and `@borealis/layout-fastify` build one spy per server, so any suite with a server per test hits this.

## How

Sockets are tracked in a `Map` of async id to `WeakRef`, so the spy retains nothing, and `disable()` walks them and detaches. The listener is shared per spy so that `removeListener` has a reference to match on.

The hook's `destroy` callback drops each entry as its socket closes, so the map stays bounded to sockets which are actually open: 5000 sequential connections peak at 5 tracked entries and settle back to 0. Adding `destroy` measured at ~2% on top of the `init` hook the library already installs.

The deferred attachment in `process.nextTick` is skipped if the spy was disabled in the meantime. It always runs ahead of `destroy` — verified for a socket created and destroyed in the same tick — so an entry cannot outlive its socket.

## Tests

`The spy detaches from open sockets when disabled` connects to `127.0.0.1`; an IP literal performs no DNS lookup, so the listener is never consumed and can be counted. It asserts the count drops by exactly one across `disable()` — a delta, because spies from earlier tests in the file are still attached. Fails on stock `lib/spy.js` (`expected 2, actual 3`), passes with the fix.

## Note

`.eslintrc` gains `"env": {"es2021": true}`. airbnb-base pins `ecmaVersion` to 2018, so `WeakRef` tripped `no-undef`. `WeakRef` is available from Node 14.6, which the 14.x/16.x CI matrix satisfies.
